### PR TITLE
Python 3.11 fixes, pull in upstream

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Version 0.3.0
+-------------
+(released on January 13th 2015)
+
+- Added support for Python3
+
 Version 0.2.0
 -------------
 (released on October 15th 2012)

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,10 @@ To install run the command::
 
     pip install skills
 
+The match quality function of TrueSkill will run much faster with NumPy than with the provided matrix implementation.  Install with::
+
+    pip install numpy
+
 For details on how to use this project, see the accompanying unit tests with
 this project.  You can run the tests by running the commands::
 

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@ For more details on how the algorithm works, see
 
 http://www.moserware.com/2010/03/computing-your-skill.html
 
+To install run the command::
+
+    pip install skills
+
 For details on how to use this project, see the accompanying unit tests with
 this project.  You can run the tests by running the commands::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='skills',
-    version='0.2.0',
+    version='0.3.0',
     author='Scott Hamilton',
     author_email='mcleopold@gmail.com',
     packages=['skills',
@@ -15,13 +15,14 @@ setup(
     description='Implementation of the TrueSkill, Glicko'
                 ' and Elo Ranking Algorithms',
     long_description=open('README.rst').read(),
+    keywords='skill trueskill glicko elo',
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Other Environment',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='skills',
@@ -18,6 +18,7 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Development Status :: 4 - Beta',

--- a/skills/__init__.py
+++ b/skills/__init__.py
@@ -1,7 +1,6 @@
 """Ranking calculators implementing the Elo, Glicko and TrueSkill algorithms."""
-from __future__ import absolute_import
+from collections.abc import Sequence
 
-from collections import Sequence
 from skills.numerics import Gaussian
 
 
@@ -40,6 +39,7 @@ class Match(list):
     """Match is a list of Team objects"""
 
     def __init__(self, teams=None, rank=None):
+        super().__init__()
         if teams is not None:
             for team in teams:
                 self.append(Team.ensure_team(team))
@@ -87,7 +87,7 @@ class Match(list):
             for player_rating in team.player_rating():
                 yield player_rating
 
-    def sort(self):
+    def sort(self, **kwargs):
         """
         Performs an in-place sort of the items in accordance to the ranks in non-decreasing order
         """
@@ -126,6 +126,7 @@ class Matches(list):
     """Matches is a list of Match objects"""
 
     def __init__(self, matches):
+        super().__init__()
         for match in matches:
             self.append(Match.ensure_match(match))
 
@@ -193,7 +194,8 @@ class Team(dict):
 
             # or 1 list of player, rating tuples
             team = Team([(player1, rating1), (player2, rating2)])
-        '''
+        """
+        super().__init__()
         if players is not None:
             try:
                 player_rating_tuples = players.items()
@@ -244,10 +246,10 @@ class Team(dict):
             return team
 
     def __lt__(self, other):
-        '''
+        """
         In python3, you can't order dicts anymore. Since we do that in Match.sort
         we'll define a custom team sort based on the current contents for consistency
-        '''
+        """
         return frozenset(self.items()) < frozenset(other.items())
 
 
@@ -263,14 +265,14 @@ class Rating(object):
             raise ValueError("Rating mean value must be numeric")
 
     def __repr__(self):
-        return "Rating(%s)" % (self.mean)
+        return "Rating(%s)" % self.mean
 
     def __str__(self):
-        return "mean=%.5f" % (self.mean)
+        return "mean=%.5f" % self.mean
 
     @staticmethod
     def ensure_rating(rating):
-        if (not hasattr(rating, 'mean')):
+        if not hasattr(rating, 'mean'):
             try:
                 return Rating(rating)
             except TypeError:
@@ -288,8 +290,9 @@ class RatingFactory(object):
 
     rating_class = Rating
 
-    def __new__(cls):
-        return RatingFactory.rating_class()
+    # def __new__(cls):
+    #     TODO: Rating ctor requires a param
+    #     return RatingFactory.rating_class()
 
     @staticmethod
     def ensure_rating(rating):

--- a/skills/__init__.py
+++ b/skills/__init__.py
@@ -94,7 +94,7 @@ class Match(list):
         if not self.rank:
             raise AttributeError("Match does not have a ranking")
 
-        rank_sorted, teams_sorted = map(list, zip(*sorted(zip(self.rank, self))))
+        rank_sorted, teams_sorted = map(list, zip(*sorted(zip(self.rank, self), key=lambda x: x[0])))
 
         if rank_sorted != self.rank:
             # in-place update part
@@ -204,14 +204,14 @@ class Team(dict):
             except (TypeError, ValueError):
                 raise TypeError("Improper player dict or list")
 
-    def player_rating(self):
-        return list(self.items())
+    def players(self):
+        return list(self.keys())
 
     def ratings(self):
         return list(self.values())
 
-    def players(self):
-        return list(self.keys())
+    def player_rating(self):
+        return list(self.items())
 
     def add_player(self, player, rating):
         self[Player.ensure_player(player)] = RatingFactory.ensure_rating(rating)

--- a/skills/__init__.py
+++ b/skills/__init__.py
@@ -178,23 +178,20 @@ class Team(dict):
     def __init__(self, players=None):
         '''
         Construct a team dictionary
-        
+
         Allows for a dictionary of players to ratings
             or a list of player, rating tuples
-        
+
         Ensure players and ratings are of the proper class
         Allows for easy creation of team object using dictionaries or lists
-        
+
             # passing 1 argument assumes 1 player to rating dictionary
             team = Team({1: (mean1, stdev1), 2: (mean2, stdev2)})
             team = Team({player1: rating1, player2: rating2})
-            
+
             # or 1 list of player, rating tuples
             team = Team([(player1, rating1), (player2, rating2)])
         '''
-        self.players = self.keys
-        self.ratings = self.values
-        self.player_rating = self.items
         if players is not None:
             try:
                 player_rating_tuples = players.items()
@@ -206,6 +203,15 @@ class Team(dict):
                                     RatingFactory.ensure_rating(rating))
             except (TypeError, ValueError):
                 raise TypeError("Improper player dict or list")
+
+    def player_rating(self):
+        return list(self.items())
+
+    def ratings(self):
+        return list(self.values())
+
+    def players(self):
+        return list(self.keys())
 
     def add_player(self, player, rating):
         self[Player.ensure_player(player)] = RatingFactory.ensure_rating(rating)
@@ -234,6 +240,13 @@ class Team(dict):
             return Team(team)
         else:
             return team
+
+    def __lt__(self, other):
+        '''
+        In python3, you can't order dicts anymore. Since we do that in Match.sort
+        we'll define a custom team sort based on the current contents for consistency
+        '''
+        return frozenset(self.items()) < frozenset(other.items())
 
 
 class Rating(object):

--- a/skills/elo.py
+++ b/skills/elo.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from collections import Sequence
+from collections.abc import Sequence
 
 from skills import (
     Calculator,

--- a/skills/factorgraph.py
+++ b/skills/factorgraph.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-
-
 class Factor(object):
 
     def __init__(self, name):

--- a/skills/glicko.py
+++ b/skills/glicko.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import
-
-from collections import Sequence, defaultdict
+from collections import defaultdict
+from collections.abc import Sequence
 from math import sqrt, log, pi
 
 from skills import (

--- a/skills/matrix.py
+++ b/skills/matrix.py
@@ -14,7 +14,7 @@ class Matrix(list):
             self.append(row[:])
 
     def transpose(self):
-        return Matrix(map(lambda * row: list(row), *self))
+        return Matrix(list(map(lambda * row: list(row), *self)))
 
     def is_square(self):
         return self.shape[0] == self.shape[1] and self.shape[0] > 0

--- a/skills/matrix.py
+++ b/skills/matrix.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-
-
 class MatrixError(Exception):
     pass
 
@@ -10,6 +7,7 @@ class Matrix(list):
     ERROR_TOLERANCE = 0.00000000000001
 
     def __init__(self, data):
+        super().__init__()
         rows = len(data)
         cols = len(data[0]) if rows > 0 else 0
         self.shape = rows, cols

--- a/skills/numerics.py
+++ b/skills/numerics.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-
+from __future__ import division, absolute_import
 from math import sqrt, pi, log, exp
 
 try:
@@ -132,13 +131,10 @@ class Gaussian(object):
 
         return -LOG_SQRT_2_PI - (log(variance_sum) / 2.0) - ((mean_difference ** 2.0) / (2.0 * variance_sum))
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         return Gaussian.from_precision_mean(
             self.precision_mean - other.precision_mean,
             self.precision - other.precision)
-
-    # In python3, __div__ was removed in favor of __truediv__
-    __truediv__ = __div__
 
     @staticmethod
     def log_ratio_normalization(numerator, denominator):

--- a/skills/numerics.py
+++ b/skills/numerics.py
@@ -1,4 +1,3 @@
-from __future__ import division, absolute_import
 from math import sqrt, pi, log, exp
 
 try:

--- a/skills/numerics.py
+++ b/skills/numerics.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from math import sqrt, pi, log, exp
 
 try:
@@ -5,7 +7,7 @@ try:
     Matrix.determinant = lambda m: linalg.det(m)
     Matrix.inverse = lambda m: m.I
 except ImportError:
-    from matrix import Matrix
+    from .matrix import Matrix
 
 
 SQRT_2_PI = sqrt(2.0 * pi)
@@ -134,6 +136,9 @@ class Gaussian(object):
         return Gaussian.from_precision_mean(
             self.precision_mean - other.precision_mean,
             self.precision - other.precision)
+
+    # In python3, __div__ was removed in favor of __truediv__
+    __truediv__ = __div__
 
     @staticmethod
     def log_ratio_normalization(numerator, denominator):

--- a/skills/testsuite/test_numerics.py
+++ b/skills/testsuite/test_numerics.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import unittest
 from skills.numerics import Gaussian
 from math import sqrt

--- a/skills/testsuite/test_numerics.py
+++ b/skills/testsuite/test_numerics.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import unittest
 from skills.numerics import Gaussian
 from math import sqrt

--- a/skills/trueskill/__init__.py
+++ b/skills/trueskill/__init__.py
@@ -1,8 +1,6 @@
-from __future__ import absolute_import
-
 from math import sqrt, exp
 
-from collections import Sequence
+from collections.abc import Sequence
 
 from skills import (
     Calculator,

--- a/skills/trueskill/__init__.py
+++ b/skills/trueskill/__init__.py
@@ -75,7 +75,7 @@ class TrueSkillGameInfo(object):
             raise ValueError("TrueSkillGameInfo arguments must be numeric")
 
     def default_rating(self):
-        return Rating(self.initial_mean, self.initial_stdev)
+        return GaussianRating(self.initial_mean, self.initial_stdev)
 
     @staticmethod
     def ensure_game_info(game_info):

--- a/skills/trueskill/factors.py
+++ b/skills/trueskill/factors.py
@@ -177,7 +177,7 @@ class GaussianWeightedSumFactor(GaussianFactor):
 
         # the first weights are a straightforward copy
         self.weights.append(variable_weights[:])
-        self.weights_squared.append(map(lambda x: x ** 2, variable_weights))
+        self.weights_squared.append(list(map(lambda x: x ** 2, variable_weights)))
 
         # 0..n-1
         self.variable_index_orders_for_weights = [list(range(len(variables_to_sum) + 1))]

--- a/skills/trueskill/factors.py
+++ b/skills/trueskill/factors.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from math import sqrt, log
 from copy import copy
 

--- a/skills/trueskill/factors.py
+++ b/skills/trueskill/factors.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from math import sqrt, log
 from copy import copy
 

--- a/skills/trueskill/layers.py
+++ b/skills/trueskill/layers.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from skills.factorgraph import (
     FactorGraphLayer,
     ScheduleLoop,

--- a/skills/trueskill/truncated.py
+++ b/skills/trueskill/truncated.py
@@ -2,8 +2,6 @@
 Truncated gaussian correction functions
 from the bottom of page 4 of the TrueSkill paper
 """
-from __future__ import absolute_import
-
 from skills.numerics import Gaussian
 
 
@@ -13,7 +11,7 @@ def v_exceeds_margin_scaled(team_performance_difference, draw_margin, c):
 
 def v_exceeds_margin(team_performance_difference, draw_margin):
     denominator = Gaussian.cumulative_to(team_performance_difference - draw_margin)
-    if (denominator < 2.22275874e-162):
+    if denominator < 2.22275874e-162:
         return -team_performance_difference + draw_margin
     return Gaussian.at(team_performance_difference - draw_margin) / denominator
 


### PR DESCRIPTION
The existing branch was not working with Python 3.11. I've updated all collections imports to be `abc` where appropriate (Sequence). Further, there were some small things that weren't playing well with our branch and 3.11, like using div or truediv, which upstream fixed a while back. As such, I pulled in upstream to avoid doing redundant divergent work. Finally, I did some house-keeping on the code where PyCharm was (sometimes rightly, like not calling super) upset about it.